### PR TITLE
Type-aware config loading and docs refresh

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,17 +1,13 @@
 # @wafl-lang/cli
 ![NPM Downloads](https://img.shields.io/npm/d18m/%40wafl-lang%2Fcli)
 
-Global launcher for the WAFL command line interface. It delegates to `@wafl-lang/config`'s binary so you can run WAFL commands from anywhere.
+Global WAFL command line interface. Provides the `wafl` binary to parse, resolve, evaluate, and validate `.wafl` config files (imports, tags, expressions, `@schema`).
 
 ## Install
 
 - Global: `pnpm add -g @wafl-lang/cli` (or `npm i -g @wafl-lang/cli`)
 - Ad‑hoc: `npx @wafl-lang/cli --help`
-
-## Tests
-
-- From repo root: `pnpm test --filter @wafl-lang/cli`
-- Direct: `cd packages/cli && node --test`
+- Required runtime: Node 18+
 
 ## Usage
 
@@ -25,11 +21,18 @@ Commands:
 Options:
   --out=FILE           Write result JSON to file
   --env.KEY=value      Inject environment variable
+  --quiet              Silence logs
 ```
 
 Examples:
 
 - `wafl build config/app.wafl --out=dist/app.json`
 - `wafl validate config/app.wafl --env.NODE_ENV=production`
+- Use without install: `npx @wafl-lang/cli build examples/app.config.wafl`
 
-`@wafl-lang/cli` will locate the installed `@wafl-lang/config` package and forward the arguments to its CLI implementation.
+If validation fails or a file is missing, the command exits non‑zero with an error message.
+
+## Testing (in this repo)
+
+- From repo root: `pnpm test --filter @wafl-lang/cli`
+- Direct: `cd packages/cli && pnpm test`

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,17 +1,15 @@
 # @wafl-lang/config
 ![NPM Downloads](https://img.shields.io/npm/d18m/%40wafl-lang%2Fconfig)
 
-CLI and Node API for loading WAFL configuration files. It wraps the WAFL core engine with a user-friendly executable and helper utilities.
+Loader and CLI for WAFL configuration files. Ships both a Node API (`loadConfig`) and a `wafl` CLI that parse, resolve, evaluate, and validate `.wafl` configs (imports, tags, expressions, and `@schema` blocks).
 
 ## Install
 
-- Project dependency: `pnpm add @wafl-lang/config` (workspace uses `@wafl-lang/core` automatically)
-- Global CLI via the launcher: `pnpm add -g @wafl-lang/cli` or run directly with `npx @wafl-lang/config`
+- Add to a project: `pnpm add @wafl-lang/config`
+- Use the CLI without install: `npx @wafl-lang/config validate path/to/app.wafl`
+- Globally (optional): `pnpm add -g @wafl-lang/config`
 
-## Tests
-
-- From repo root: `pnpm test --filter @wafl-lang/config`
-- Direct: `cd packages/config && node --test`
+Requires Node 18+.
 
 ## CLI
 
@@ -25,6 +23,7 @@ Commands:
 Options:
   --out=FILE           Write result JSON to file
   --env.KEY=value      Inject environment variable
+  --quiet              Silence logs
 ```
 
 Examples:
@@ -44,4 +43,16 @@ const config = await loadConfig("config/app.wafl", {
 // config now contains the fully resolved, evaluated, and validated JSON object
 ```
 
-`loadConfig` resolves tags, evaluates expressions, and validates the document (using either inline `@schema` or referenced schema metadata). It throws if the file is missing or validation fails.
+What `loadConfig` does:
+
+- Reads the `.wafl` file and its `@import` dependencies (relative paths supported).
+- Extracts `@schema` metadata and validates the final document (throws on mismatch).
+- Resolves tags (`!tag(args)`), conditions (`- if ...:`), and `$ENV` expressions.
+- Evaluates inline expressions (e.g., `port = $ENV.PORT || 3000`) with `env` merged over `process.env`.
+
+Errors surface as regular exceptions with context; wrap in `try/catch` if you want custom handling.
+
+## Testing (in this repo)
+
+- From repo root: `pnpm test --filter @wafl-lang/config`
+- Direct: `cd packages/config && pnpm test`

--- a/packages/config/src/index.mjs
+++ b/packages/config/src/index.mjs
@@ -1,9 +1,6 @@
 import fs from "fs";
 import path from "path";
-import { loadWaflFile } from "@wafl-lang/core/loader.mjs";
-import { evaluateDocument } from "@wafl-lang/core/eval.mjs";
-import { resolveWafl } from "@wafl-lang/core/resolver.mjs";
-import { validateDocument } from "@wafl-lang/core/schema.mjs";
+import { loadWaflConfig } from "@wafl-lang/core";
 
 /**
  * Loads and evaluates a .wafl configuration file.
@@ -20,59 +17,7 @@ export async function loadConfig(filePath, { env = process.env } = {}) {
   }
 
   console.log(`[WAFL CONFIG] Loading ${absPath}`);
-
-  // Step 1: Load and parse (imports + schema + eval)
-  const { doc, meta } = loadWaflFile(absPath, { env });
-
-  // Step 1.5: Extract type metadata from keys before resolution
-  const typeMetadata = extractTypeMetadata(doc);
-
-  // Step 2: Resolve tags, conditions, and expressions
-  const resolved = resolveWafl(doc, { env });
-
-  // Step 3: Evaluate @eval blocks and embedded expressions
-  const evaluated = evaluateDocument(resolved, { env });
-
-  // Step 4: Validate against schema
-  const schema = meta.schema || evaluated["@schema"];
-  if (schema) {
-    console.log("[WAFL CONFIG] Validating schema...");
-    validateDocument(evaluated, schema, typeMetadata);
-  }
-
+  const config = await loadWaflConfig(absPath, { env });
   console.log("[WAFL CONFIG] Configuration loaded successfully.\n");
-  return evaluated;
-}
-
-/**
- * Extracts type metadata from document keys (e.g., app<App> -> {app: "App"})
- *
- * @param {object} doc - The document to extract type metadata from
- * @returns {object} Map of key names to their type annotations
- */
-function extractTypeMetadata(doc) {
-  const metadata = {};
-
-  function walk(obj, path = "") {
-    if (!obj || typeof obj !== "object" || Array.isArray(obj)) return;
-
-    for (const key of Object.keys(obj)) {
-      const match = key.match(/^(.*)<([A-Za-z0-9_]+)>$/);
-      if (match) {
-        const baseKey = match[1] || key;
-        const typeName = match[2];
-        const fullPath = path ? `${path}.${baseKey}` : baseKey;
-        metadata[fullPath] = typeName;
-      }
-
-      // Recurse into nested objects
-      if (obj[key] && typeof obj[key] === "object" && !Array.isArray(obj[key])) {
-        const nextPath = path ? `${path}.${key.replace(/<.*>$/, "")}` : key.replace(/<.*>$/, "");
-        walk(obj[key], nextPath);
-      }
-    }
-  }
-
-  walk(doc);
-  return metadata;
+  return config;
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,18 +1,14 @@
 # @wafl-lang/core
+
 ![NPM Downloads](https://img.shields.io/npm/d18m/%40wafl-lang%2Fcore)
 
 Core engine for the Wider Attribute Formatting Language (WAFL): parsing, resolving tags/expressions, evaluating documents, and validating against schemas.
 
 ## Install
 
-Add to your project (workspace-aware): `pnpm add @wafl-lang/core`
+Add to a project: `pnpm add @wafl-lang/core` (Node 18+)
 
-## Tests
-
-- From repo root: `pnpm test --filter @wafl-lang/core`
-- Direct: `cd packages/core && node --test`
-
-## Usage
+## High-level usage
 
 ```js
 import { loadWaflConfig } from "@wafl-lang/core";
@@ -24,7 +20,27 @@ const result = await loadWaflConfig("config/app.wafl", {
 // result holds the fully resolved, evaluated, and validated configuration object
 ```
 
-### Lower-level APIs
+### Load from a string (no filesystem)
+
+```js
+import { loadWaflConfigFromString } from "@wafl-lang/core";
+
+const source = `
+@schema:
+  App:
+    name: string
+    port: int
+
+app<App>:
+  name: "Demo"
+  port = $ENV.PORT || 3000
+`;
+
+const result = await loadWaflConfigFromString(source, { env: { PORT: 4242 } });
+// => { app: { name: "Demo", port: 4242 } }
+```
+
+## Lower-level APIs
 
 If you need finer control, import specific modules:
 
@@ -40,4 +56,16 @@ const evaluated = evaluateDocument(resolved, { env: process.env });
 validateDocument(evaluated, meta.schema);
 ```
 
-`loadWaflFile` parses `.wafl` files, `resolveWafl` handles imports/tags/conditions, `evaluateDocument` runs `@eval` blocks and expressions, and `validateDocument` enforces schemas so you can plug these pieces into your own pipeline.
+`loadWaflFile` parses `.wafl` files (and `@import`s), `resolveWafl` handles tags/conditions/expressions, `evaluateDocument` runs `@eval` blocks and expressions, and `validateDocument` enforces schemas so you can plug these pieces into your own pipeline.
+
+## What’s included
+
+- Parser for indentation-based `.wafl` syntax with tags (`!tag(args)`), lists, and expressions (`key = expr`).
+- Resolver/evaluator for `$ENV` expressions, conditionals (`- if ...`), and custom tags.
+- Schema validation via `@schema` blocks; supports optional fields (`field?`) and typed lists (`list<string>`).
+- Type metadata extraction from keys like `app<App>` to enforce validation on the right paths.
+
+## Testing (in this repo)
+
+- From repo root: `pnpm test --filter @wafl-lang/core`
+- Direct: `cd packages/core && pnpm test`

--- a/packages/core/src/utils.mjs
+++ b/packages/core/src/utils.mjs
@@ -35,3 +35,36 @@ export function deepMerge(a, b) {
   }
   return b;
 }
+
+/**
+ * Extracts type annotations from keys that follow the pattern key<Type>.
+ *
+ * @param {object} doc - The document tree to inspect
+ * @returns {object} Map of dotted paths to their associated type names
+ */
+export function extractTypeMetadata(doc) {
+  const metadata = {};
+
+  function walk(obj, path = "") {
+    if (!obj || typeof obj !== "object" || Array.isArray(obj)) return;
+
+    for (const key of Object.keys(obj)) {
+      const match = key.match(/^(.*)<([A-Za-z0-9_]+)>$/);
+      if (match) {
+        const baseKey = match[1] || key;
+        const typeName = match[2];
+        const fullPath = path ? `${path}.${baseKey}` : baseKey;
+        metadata[fullPath] = typeName;
+      }
+
+      if (obj[key] && typeof obj[key] === "object" && !Array.isArray(obj[key])) {
+        const cleanKey = key.replace(/<.*>$/, "");
+        const nextPath = path ? `${path}.${cleanKey}` : cleanKey;
+        walk(obj[key], nextPath);
+      }
+    }
+  }
+
+  walk(doc);
+  return metadata;
+}

--- a/packages/core/test/load-config.test.mjs
+++ b/packages/core/test/load-config.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { loadWaflConfig } from "../src/index.mjs";
+
+test("loadWaflConfig throws when schema validation fails", async () => {
+  const tmpDir = mkdtempSync(path.join(os.tmpdir(), "wafl-config-"));
+  const configPath = path.join(tmpDir, "app.wafl");
+
+  writeFileSync(
+    configPath,
+    [
+      "@schema:",
+      "  App:",
+      "    name: string",
+      "    port: int",
+      "",
+      "app<App>:",
+      '  name: "Demo"',
+      // port is intentionally missing
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  try {
+    await assert.rejects(
+      () => loadWaflConfig(configPath, { env: {} }),
+      /Required field 'port'/,
+    );
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/test/load-from-string.test.mjs
+++ b/packages/core/test/load-from-string.test.mjs
@@ -27,3 +27,22 @@ test("loadWaflConfigFromString parses, evaluates, and validates WAFL source", as
     },
   });
 });
+
+test("loadWaflConfigFromString throws on schema mismatch", async () => {
+  const source = [
+    "@schema:",
+    "  App:",
+    "    name: string",
+    "    port: int",
+    "",
+    "app<App>:",
+    '  name: "Demo"',
+    // port is intentionally missing
+    "",
+  ].join("\n");
+
+  await assert.rejects(
+    () => loadWaflConfigFromString(source, { env: {} }),
+    /Required field 'port'/,
+  );
+});


### PR DESCRIPTION
- share type metadata extraction across core/config loaders and enforce schema errors for file/string loads

- have config package delegate to core loader and keep env passthrough

- make core/config/cli READMEs self-contained with usage examples (including loadWaflConfigFromString)